### PR TITLE
fix(vagrant file): vm:8000 forward to host:80

### DIFF
--- a/Vagrantfile.temp
+++ b/Vagrantfile.temp
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # NOTE: This will enable public access to the opened port
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 8000, host: 80
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine and only allow access


### PR DESCRIPTION
修复端口映射，在虚拟机里通过命令 `python manage.py runserver 0.0.0.0:8000` 启动 Django 后，在宿主机直接输入 <http://localhost> 即可访问虚拟机的 Django 服务。